### PR TITLE
chore(changelog): remove empty releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,9 @@
-## [1.0.23](https://github.com/dankreiger/tiny-either/compare/v1.0.22...v1.0.23) (2022-01-12)
-
-## [1.0.22](https://github.com/dankreiger/tiny-either/compare/v1.0.21...v1.0.22) (2022-01-07)
-
-## [1.0.21](https://github.com/dankreiger/tiny-either/compare/v1.0.20...v1.0.21) (2022-01-07)
-
-## [1.0.20](https://github.com/dankreiger/tiny-either/compare/v1.0.19...v1.0.20) (2022-01-07)
-
-## [1.0.19](https://github.com/dankreiger/tiny-either/compare/v1.0.18...v1.0.19) (2022-01-07)
-
-## [1.0.18](https://github.com/dankreiger/tiny-either/compare/v1.0.17...v1.0.18) (2022-01-07)
-
-## [1.0.17](https://github.com/dankreiger/tiny-either/compare/v1.0.16...v1.0.17) (2022-01-07)
-
-## [1.0.16](https://github.com/dankreiger/tiny-either/compare/v1.0.15...v1.0.16) (2022-01-07)
-
-## [1.0.15](https://github.com/dankreiger/tiny-either/compare/v1.0.14...v1.0.15) (2022-01-07)
-
-## [1.0.14](https://github.com/dankreiger/tiny-either/compare/v1.0.13...v1.0.14) (2022-01-07)
-
 ## [1.0.13](https://github.com/dankreiger/tiny-either/compare/v1.0.12...v1.0.13) (2022-01-06)
 
 
 ### Features
 
 * **functions:** add fromPredicate ([#34](https://github.com/dankreiger/tiny-either/issues/34)) ([7f04937](https://github.com/dankreiger/tiny-either/commit/7f049373c9ebe2c74d5edddefe0080a899ff5749))
-
-## [1.0.12](https://github.com/dankreiger/tiny-either/compare/v1.0.11...v1.0.12) (2021-12-11)
-
-## [1.0.11](https://github.com/dankreiger/tiny-either/compare/v1.0.10...v1.0.11) (2021-10-05)
-
-## [1.0.10](https://github.com/dankreiger/tiny-either/compare/v1.0.9...v1.0.10) (2021-10-05)
-
-## [1.0.9](https://github.com/dankreiger/tiny-either/compare/v1.0.8...v1.0.9) (2021-10-02)
 
 ## [1.0.8](https://github.com/dankreiger/tiny-either/compare/v1.0.7...v1.0.8) (2021-10-01)
 


### PR DESCRIPTION
These were triggered by bots doing dependency updates.